### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Openwrt-AutoBuild.yml
+++ b/.github/workflows/Openwrt-AutoBuild.yml
@@ -8,6 +8,12 @@
 
 name: Build OpenWrt
 
+permissions:
+  contents: read
+  actions: write
+  packages: write
+  pull-requests: write
+
 on: 
   repository_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/iamjairo/Kwrt/security/code-scanning/2](https://github.com/iamjairo/Kwrt/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's operations, the following permissions are likely sufficient:
- `contents: read` for accessing repository contents.
- `actions: write` for managing workflow runs.
- `packages: write` for interacting with packages.
- `pull-requests: write` for creating or updating pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to individual jobs if different jobs require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
